### PR TITLE
Add tf2_server::steamcmd class

### DIFF
--- a/manifests/steamcmd.pp
+++ b/manifests/steamcmd.pp
@@ -1,0 +1,18 @@
+class tf2_server::steamcmd {
+  user { "steam":
+    ensure     => "present",
+    managehome => true,
+  }
+  file { '/home/steam/hlds':
+    ensure => 'directory',
+  }
+  class { 'staging':
+    path  => '/home/steam',
+    owner => 'steam',
+    group => 'steam',
+  }
+  staging::deploy { 'steamcmd_linux.tar.gz':
+    source => 'http://media.steampowered.com/installer/steamcmd_linux.tar.gz',
+    target => '/home/steam/hlds',
+  }
+}

--- a/tests/steamcmd.pp
+++ b/tests/steamcmd.pp
@@ -1,0 +1,1 @@
+include tf2_server::steamcmd


### PR DESCRIPTION
Add a tf2_server::steamcmd class, which will use puppet to install
steamcmd into the /home/steam/hlds directory.
