### PR TITLE
Add support for additional server.cfg options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ The `tf2_server` class contains a number of parameters. These include:
 * `mapcycle`: An array containing the maps in your mapcycle in the order they appear in the mapcycle.
   Defaults to `['ctf_2fort']`.
 * `motd`: Your server's message of the day.
-
-This class also has the `hostname`, `rcon_password`, `sv_contact`, and `map_timelimit`
-parameters. These correspond to values set in your `server.cfg` file.
+* `hostname`: The hostname of your server.
+* `server_options`: A hash containing any additional options you want to set in your `server.cfg` file.
+  Each key in this hash should be the name of a setting, with its value being the value of the corresponding
+  setting.
 
 ##Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,7 @@
 class tf2_server::config inherits tf2_server {
   file { "$server_install_dir/tf2/tf/cfg/server.cfg":
     ensure => file,
-    content => "hostname \"$hostname\"
-                rcon_password \"$rcon_password\"
-                sv_contact \"$sv_contact\"
-                mp_timelimit \"$map_timelimit\"",
+    content => template("tf2_server/server.cfg.erb"),
   }
   file { "$server_install_dir/tf2/tf/cfg/motd.txt":
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,6 @@ class tf2_server (
   $server_owner = $tf2_server::params::server_owner,
   $staging_dir = $tf2_server::params::staging_dir,
   $hostname = $tf2_server::params::hostname,
-  $rcon_password = $tf2_server::params::rcon_password,
-  $sv_contact = $tf2_server::params::sv_contact,
-  $map_timelimit = $tf2_server::params::map_timelimit,
   $motd = $tf2_server::params::motd,
   $service_ensure = $tf2_server::params::service_ensure,
   $service_manage = $tf2_server::params::service_manage,
@@ -13,6 +10,7 @@ class tf2_server (
   $start_map = $tf2_server::params::start_map,
   $maplist = $tf2_server::params::maplist,
   $mapcycle = $tf2_server::params::mapcycle,
+  $server_options = $tf2_server::params::server_options,
 ) inherits tf2_server::params {
   include tf2_server::install
   include tf2_server::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,11 +6,11 @@ class tf2_server::params {
   $service_manage = true
   $service_enable = true
   $hostname = 'tf2_test_server'
-  $rcon_password = 'abcd1234'
-  $sv_contact = 'fakename@fakedomain'
-  $map_timelimit = '30'
   $motd = 'This is a message of the day.'
   $start_map = 'ctf_2fort'
   $maplist = ['ctf_2fort']
   $mapcycle = ['ctf_2fort']
+  $server_options = { rcon_password => 'abcd1234',
+                      sv_contact => 'fakename@fakedomain',
+                      map_timelimit => '30', }
 }

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -1,0 +1,6 @@
+hostname "<%= @hostname %>"
+<%=  settings = ""
+    @server_options.each do |key, value|
+      settings += "#{key} \"#{value}\"\n"
+    end
+    settings %>


### PR DESCRIPTION
Add server_options parameter, which is a hash containing all
options the user wants to go into their server.cfg file. This
allows the user to fully configure their server.cfg file with
Puppet.
